### PR TITLE
Feature: sort NFTs by media type

### DIFF
--- a/src/components/common/item-list/item-list.tsx
+++ b/src/components/common/item-list/item-list.tsx
@@ -1,10 +1,6 @@
-import { Box, Wrap, WrapItem, useBreakpointValue } from '@chakra-ui/react';
-import { useState } from 'react';
+import { Wrap, WrapItem} from '@chakra-ui/react';
 import { Metadata } from 'vwbl-sdk';
-import { MEDIA_TYPE } from '../../../utils';
-
 import { NFTItem } from '../nft-item';
-import { SortMenu } from '../sort-menu';
 import { style } from './item-list.style';
 
 type Props = {
@@ -12,30 +8,17 @@ type Props = {
 };
 
 export const ItemList: React.FC<Props> = ({ nfts }) => {
-  const [sortType, setSortType] = useState<string>('all');
   return (
-    <Box>
-      <Box display='flex' justifyContent='right' m='auto' w={useBreakpointValue(['315px', '90vw', '630px', '960px'])}>
-        <SortMenu state={sortType} changeState={setSortType} selectOptions={MEDIA_TYPE} />
-      </Box>
-      <Wrap spacing={4} justify='center' sx={style.wrapper}>
-        {nfts.map((nft) => {
-          if (nft && sortType === MEDIA_TYPE.All) {
-            return (
-              <WrapItem key={nft.id} my={2} style={style.wrapItem}>
-                <NFTItem nft={nft} />
-              </WrapItem>
-            );
-          }
-          if (nft && sortType === nft.mimeType.split('/')[0]) {
-            return (
-              <WrapItem key={nft.id} my={2} style={style.wrapItem}>
-                <NFTItem nft={nft} />
-              </WrapItem>
-            );
-          }
-        })}
-      </Wrap>
-    </Box>
+    <Wrap spacing={4} justify='center' sx={style.wrapper}>
+      {nfts.map((nft) => {
+        if (nft) {
+          return (
+            <WrapItem key={nft.id} my={2} style={style.wrapItem}>
+              <NFTItem nft={nft} />
+            </WrapItem>
+          );
+        }
+      })}
+    </Wrap>
   );
 };

--- a/src/components/common/item-list/item-list.tsx
+++ b/src/components/common/item-list/item-list.tsx
@@ -1,7 +1,10 @@
-import { Wrap, WrapItem } from '@chakra-ui/react';
+import { Box, Wrap, WrapItem, useBreakpointValue } from '@chakra-ui/react';
+import { useState } from 'react';
 import { Metadata } from 'vwbl-sdk';
+import { MEDIA_TYPE } from '../../../utils';
 
 import { NFTItem } from '../nft-item';
+import { SortMenu } from '../sort-menu';
 import { style } from './item-list.style';
 
 type Props = {
@@ -9,17 +12,30 @@ type Props = {
 };
 
 export const ItemList: React.FC<Props> = ({ nfts }) => {
+  const [sortType, setSortType] = useState<string>('all');
   return (
-    <Wrap spacing={4} justify='center' sx={style.wrapper}>
-      {nfts.map((nft) => {
-        if (nft) {
-          return (
-            <WrapItem key={nft.id} my={2} style={style.wrapItem}>
-              <NFTItem nft={nft} />
-            </WrapItem>
-          );
-        }
-      })}
-    </Wrap>
+    <Box>
+      <Box display='flex' justifyContent='right' m='auto' w={useBreakpointValue(['315px', '90vw', '630px', '960px'])}>
+        <SortMenu state={sortType} changeState={setSortType} selectOptions={MEDIA_TYPE} />
+      </Box>
+      <Wrap spacing={4} justify='center' sx={style.wrapper}>
+        {nfts.map((nft) => {
+          if (nft && sortType === MEDIA_TYPE.All) {
+            return (
+              <WrapItem key={nft.id} my={2} style={style.wrapItem}>
+                <NFTItem nft={nft} />
+              </WrapItem>
+            );
+          }
+          if (nft && sortType === nft.mimeType.split('/')[0]) {
+            return (
+              <WrapItem key={nft.id} my={2} style={style.wrapItem}>
+                <NFTItem nft={nft} />
+              </WrapItem>
+            );
+          }
+        })}
+      </Wrap>
+    </Box>
   );
 };

--- a/src/components/common/sort-menu/index.ts
+++ b/src/components/common/sort-menu/index.ts
@@ -1,0 +1,1 @@
+export * from './sort-menu';

--- a/src/components/common/sort-menu/sort-menu.tsx
+++ b/src/components/common/sort-menu/sort-menu.tsx
@@ -1,18 +1,19 @@
 import { ChevronDownIcon, CheckIcon } from '@chakra-ui/icons';
 import { Button, Menu, MenuButton, Text, MenuList, MenuItem } from '@chakra-ui/react';
+import { useState } from 'react';
 
 type stringObject = {
   [key: string]: string;
 };
 
 type Props = {
-  state: string;
-  changeState: (value: string) => void;
-  selectOptions: stringObject;
+  name: string;
+  changeSortType: (value: string) => void;
+  typeOptions: stringObject;
 };
 
-export const SortMenu: React.FC<Props> = ({ state, changeState, selectOptions }) => {
-  const keys = Object.keys(selectOptions);
+export const SortMenu: React.FC<Props> = ({ name, changeSortType, typeOptions }) => {
+  const [selectedType, setSelectedType] = useState<string>('all');
   return (
     <Menu>
       <MenuButton
@@ -23,20 +24,23 @@ export const SortMenu: React.FC<Props> = ({ state, changeState, selectOptions })
         _hover={{ bg: 'white' }}
         _active={{ bg: 'white' }}
       >
-        Media
+        {name}
       </MenuButton>
       <MenuList w={180} p={4} border='solid 1px black' borderRadius='0px' _active={{ bg: 'white' }}>
-        {keys.map((key) => {
+        {Object.keys(typeOptions).map((key) => {
           return (
             <MenuItem
               key={key}
-              pl={state === selectOptions[key] ? 0 : 6}
+              pl={selectedType === typeOptions[key] ? 0 : 6}
               gap={2}
               _hover={{ bg: 'white' }}
               _focus={{ bg: 'white' }}
-              onClick={() => changeState(selectOptions[key])}
+              onClick={() => {
+                changeSortType(typeOptions[key]);
+                setSelectedType(typeOptions[key]);
+              }}
             >
-              {state === selectOptions[key] && <CheckIcon fontSize={16} />}
+              {selectedType === typeOptions[key] && <CheckIcon fontSize={16} />}
               <Text fontWeight='bold'>{key}</Text>
             </MenuItem>
           );

--- a/src/components/common/sort-menu/sort-menu.tsx
+++ b/src/components/common/sort-menu/sort-menu.tsx
@@ -1,0 +1,47 @@
+import { ChevronDownIcon, CheckIcon } from '@chakra-ui/icons';
+import { Button, Menu, MenuButton, Text, MenuList, MenuItem } from '@chakra-ui/react';
+
+type stringObject = {
+  [key: string]: string;
+};
+
+type Props = {
+  state: string;
+  changeState: (value: string) => void;
+  selectOptions: stringObject;
+};
+
+export const SortMenu: React.FC<Props> = ({ state, changeState, selectOptions }) => {
+  const keys = Object.keys(selectOptions);
+  return (
+    <Menu>
+      <MenuButton
+        as={Button}
+        rightIcon={<ChevronDownIcon />}
+        fontWeight='normal'
+        bg='white'
+        _hover={{ bg: 'white' }}
+        _active={{ bg: 'white' }}
+      >
+        Media
+      </MenuButton>
+      <MenuList w={180} p={4} border='solid 1px black' borderRadius='0px' _active={{ bg: 'white' }}>
+        {keys.map((key) => {
+          return (
+            <MenuItem
+              key={key}
+              pl={state === selectOptions[key] ? 0 : 6}
+              gap={2}
+              _hover={{ bg: 'white' }}
+              _focus={{ bg: 'white' }}
+              onClick={() => changeState(selectOptions[key])}
+            >
+              {state === selectOptions[key] && <CheckIcon fontSize={16} />}
+              <Text fontWeight='bold'>{key}</Text>
+            </MenuItem>
+          );
+        })}
+      </MenuList>
+    </Menu>
+  );
+};

--- a/src/components/common/sort-menu/sort-menu.tsx
+++ b/src/components/common/sort-menu/sort-menu.tsx
@@ -1,6 +1,5 @@
 import { ChevronDownIcon, CheckIcon } from '@chakra-ui/icons';
 import { Button, Menu, MenuButton, Text, MenuList, MenuItem } from '@chakra-ui/react';
-import { useState } from 'react';
 
 type stringObject = {
   [key: string]: string;
@@ -8,12 +7,12 @@ type stringObject = {
 
 type Props = {
   name: string;
+  sortType: string;
   changeSortType: (value: string) => void;
   typeOptions: stringObject;
 };
 
-export const SortMenu: React.FC<Props> = ({ name, changeSortType, typeOptions }) => {
-  const [selectedType, setSelectedType] = useState<string>('all');
+export const SortMenu: React.FC<Props> = ({ name, sortType, changeSortType, typeOptions }) => {
   return (
     <Menu>
       <MenuButton
@@ -31,16 +30,15 @@ export const SortMenu: React.FC<Props> = ({ name, changeSortType, typeOptions })
           return (
             <MenuItem
               key={key}
-              pl={selectedType === typeOptions[key] ? 0 : 6}
+              pl={sortType === typeOptions[key] ? 0 : 6}
               gap={2}
               _hover={{ bg: 'white' }}
               _focus={{ bg: 'white' }}
               onClick={() => {
                 changeSortType(typeOptions[key]);
-                setSelectedType(typeOptions[key]);
               }}
             >
-              {selectedType === typeOptions[key] && <CheckIcon fontSize={16} />}
+              {sortType === typeOptions[key] && <CheckIcon fontSize={16} />}
               <Text fontWeight='bold'>{key}</Text>
             </MenuItem>
           );

--- a/src/components/common/sort-menu/sort-menu.tsx
+++ b/src/components/common/sort-menu/sort-menu.tsx
@@ -1,15 +1,11 @@
 import { ChevronDownIcon, CheckIcon } from '@chakra-ui/icons';
 import { Button, Menu, MenuButton, Text, MenuList, MenuItem } from '@chakra-ui/react';
 
-type stringObject = {
-  [key: string]: string;
-};
-
 type Props = {
   name: string;
   sortType: string;
   changeSortType: (value: string) => void;
-  typeOptions: stringObject;
+  typeOptions: { [key: string]: string };
 };
 
 export const SortMenu: React.FC<Props> = ({ name, sortType, changeSortType, typeOptions }) => {

--- a/src/components/pages/nft-list/nft-list.container.tsx
+++ b/src/components/pages/nft-list/nft-list.container.tsx
@@ -1,18 +1,37 @@
 import { useState, useEffect, useCallback } from 'react';
-
 import { Metadata } from 'vwbl-sdk';
 import { NFTListComponent } from './nft-list';
-import { fetchAllTokens } from '../../../utils';
+import { fetchAllTokens, MEDIA_TYPE } from '../../../utils';
 
 export const NFTList = () => {
   const [nfts, setNfts] = useState<(Metadata | undefined)[]>([]);
+  const [sortedNFTs, setSortedNFTs] = useState<(Metadata | undefined)[]>([]);
   const [isOpenModal, setIsOpenModal] = useState<boolean>(false);
+  const [sortType, setSortType] = useState<string>('all');
 
   const loadNFTs = useCallback(async () => {
     const items = await fetchAllTokens();
     if (!items) return;
     setNfts(items.reverse());
   }, []);
+
+  const sortNFTs = (nfts: (Metadata | undefined)[], sortType: string) => {
+    if (sortType === MEDIA_TYPE.All) {
+      return nfts;
+    } else {
+      const sortedNFTs: (Metadata | undefined)[] = [];
+      for (const nft of nfts) {
+        if (sortType === nft?.mimeType.split('/')[0]) sortedNFTs.push(nft);
+      }
+      return sortedNFTs;
+    }
+  };
+
+  const changeSortType = (newType: string) => setSortType(newType);
+
+  useEffect(() => {
+    setSortedNFTs(sortNFTs(nfts, sortType));
+  }, [sortType, nfts]);
 
   useEffect(() => {
     try {
@@ -23,5 +42,12 @@ export const NFTList = () => {
     }
   }, [loadNFTs]);
 
-  return <NFTListComponent nfts={nfts} isOpenModal={isOpenModal} onCloseModal={() => setIsOpenModal(false)} />;
+  return (
+    <NFTListComponent
+      nfts={sortedNFTs}
+      isOpenModal={isOpenModal}
+      onCloseModal={() => setIsOpenModal(false)}
+      changeSortType={changeSortType}
+    />
+  );
 };

--- a/src/components/pages/nft-list/nft-list.container.tsx
+++ b/src/components/pages/nft-list/nft-list.container.tsx
@@ -15,22 +15,31 @@ export const NFTList = () => {
     setNfts(items.reverse());
   }, []);
 
-  const sortNFTs = (nfts: (Metadata | undefined)[], sortType: string) => {
+  const sortNFTsByMedia = (nfts: (Metadata | undefined)[], sortType: string) => {
+    // MediaType: All
     if (sortType === MEDIA_TYPE.All) {
       return nfts;
-    } else {
-      const sortedNFTs: (Metadata | undefined)[] = [];
+    }
+
+    const sortedNFTs: (Metadata | undefined)[] = [];
+    // MediaType: Other
+    if (sortType === MEDIA_TYPE.Other) {
       for (const nft of nfts) {
-        if (sortType === nft?.mimeType.split('/')[0]) sortedNFTs.push(nft);
+        if (nft && sortType.includes(nft.mimeType.split('/')[0])) sortedNFTs.push(nft);
       }
       return sortedNFTs;
     }
+    // MediaType: Image, Sound, Movie
+    for (const nft of nfts) {
+      if (nft && sortType === nft.mimeType.split('/')[0]) sortedNFTs.push(nft);
+    }
+    return sortedNFTs;
   };
 
   const changeSortType = (newType: string) => setSortType(newType);
 
   useEffect(() => {
-    setSortedNFTs(sortNFTs(nfts, sortType));
+    setSortedNFTs(sortNFTsByMedia(nfts, sortType));
   }, [sortType, nfts]);
 
   useEffect(() => {

--- a/src/components/pages/nft-list/nft-list.container.tsx
+++ b/src/components/pages/nft-list/nft-list.container.tsx
@@ -48,6 +48,7 @@ export const NFTList = () => {
       nfts={sortedNFTs}
       isOpenModal={isOpenModal}
       onCloseModal={() => setIsOpenModal(false)}
+      sortType={sortType}
       changeSortType={changeSortType}
     />
   );

--- a/src/components/pages/nft-list/nft-list.container.tsx
+++ b/src/components/pages/nft-list/nft-list.container.tsx
@@ -7,7 +7,7 @@ export const NFTList = () => {
   const [nfts, setNfts] = useState<(Metadata | undefined)[]>([]);
   const [sortedNFTs, setSortedNFTs] = useState<(Metadata | undefined)[]>([]);
   const [isOpenModal, setIsOpenModal] = useState<boolean>(false);
-  const [sortType, setSortType] = useState<string>('all');
+  const [sortType, setSortType] = useState<string>(MEDIA_TYPE.All);
 
   const loadNFTs = useCallback(async () => {
     const items = await fetchAllTokens();
@@ -20,20 +20,12 @@ export const NFTList = () => {
     if (sortType === MEDIA_TYPE.All) {
       return nfts;
     }
-
-    const sortedNFTs: (Metadata | undefined)[] = [];
     // MediaType: Other
     if (sortType === MEDIA_TYPE.Other) {
-      for (const nft of nfts) {
-        if (nft && sortType.includes(nft.mimeType.split('/')[0])) sortedNFTs.push(nft);
-      }
-      return sortedNFTs;
+      return nfts.filter((nft) => nft && sortType.includes(nft.mimeType.split('/')[0]));
     }
     // MediaType: Image, Sound, Movie
-    for (const nft of nfts) {
-      if (nft && sortType === nft.mimeType.split('/')[0]) sortedNFTs.push(nft);
-    }
-    return sortedNFTs;
+    return nfts.filter((nft) => nft && sortType === nft.mimeType.split('/')[0]);
   };
 
   const changeSortType = (newType: string) => setSortType(newType);

--- a/src/components/pages/nft-list/nft-list.tsx
+++ b/src/components/pages/nft-list/nft-list.tsx
@@ -1,17 +1,19 @@
-import { Container } from '@chakra-ui/react';
+import { Box, Container } from '@chakra-ui/react';
 import { Metadata } from 'vwbl-sdk';
-
 import { ItemList } from '../../common/item-list';
 import { CustomLoading } from '../../common/custom-loading';
 import { NotificationModal, notifications } from '../../common/notification-modal';
+import { SortMenu } from '../../common/sort-menu';
+import { MEDIA_TYPE } from '../../../utils';
 
 type Props = {
   nfts: (Metadata | undefined)[];
   isOpenModal: boolean;
   onCloseModal: () => void;
+  changeSortType: (arg0: string) => void;
 };
 
-export const NFTListComponent: React.FC<Props> = ({ nfts, isOpenModal, onCloseModal }) => {
+export const NFTListComponent: React.FC<Props> = ({ nfts, isOpenModal, onCloseModal, changeSortType }) => {
   if (!nfts || nfts.length === 0) {
     return <CustomLoading />;
   }
@@ -19,6 +21,9 @@ export const NFTListComponent: React.FC<Props> = ({ nfts, isOpenModal, onCloseMo
   return (
     <Container maxW='container.lg' pt={12}>
       <NotificationModal isOpen={isOpenModal} onClose={onCloseModal} notification={notifications.load_failed} />
+      <Box display='flex' justifyContent='right' px={4}>
+        <SortMenu name='Media' changeSortType={changeSortType} typeOptions={MEDIA_TYPE} />
+      </Box>
       <ItemList nfts={nfts} />
     </Container>
   );

--- a/src/components/pages/nft-list/nft-list.tsx
+++ b/src/components/pages/nft-list/nft-list.tsx
@@ -10,10 +10,11 @@ type Props = {
   nfts: (Metadata | undefined)[];
   isOpenModal: boolean;
   onCloseModal: () => void;
+  sortType: string;
   changeSortType: (arg0: string) => void;
 };
 
-export const NFTListComponent: React.FC<Props> = ({ nfts, isOpenModal, onCloseModal, changeSortType }) => {
+export const NFTListComponent: React.FC<Props> = ({ nfts, isOpenModal, onCloseModal, sortType, changeSortType }) => {
   if (!nfts || nfts.length === 0) {
     return <CustomLoading />;
   }
@@ -22,7 +23,7 @@ export const NFTListComponent: React.FC<Props> = ({ nfts, isOpenModal, onCloseMo
     <Container maxW='container.lg' pt={12}>
       <NotificationModal isOpen={isOpenModal} onClose={onCloseModal} notification={notifications.load_failed} />
       <Box display='flex' justifyContent='right' px={4}>
-        <SortMenu name='Media' changeSortType={changeSortType} typeOptions={MEDIA_TYPE} />
+        <SortMenu name='Media' sortType={sortType} changeSortType={changeSortType} typeOptions={MEDIA_TYPE} />
       </Box>
       <ItemList nfts={nfts} />
     </Container>

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -44,6 +44,5 @@ export const MEDIA_TYPE: stringObject = {
   Image: 'image',
   Movie: 'video',
   Sound: 'audio',
-  Document: 'application',
-  Data: 'text',
+  Other: 'text,application',
 };

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -1,3 +1,4 @@
+// Blockchain
 export type ChainId = 1 | 3 | 4 | 5 | 42 | 137 | 1337;
 export type Currency = {
   name: string;
@@ -31,4 +32,18 @@ export const NETWORKS: Record<ChainId, Network> = {
     },
   },
   1337: { chainName: 'Local Network', rpcUrls: ['https://localhost:8545'], blockExplorerUrls: [''] },
+};
+
+// Other
+type stringObject = {
+  [key: string]: string;
+};
+
+export const MEDIA_TYPE: stringObject = {
+  All: 'all',
+  Image: 'image',
+  Movie: 'video',
+  Sound: 'audio',
+  Document: 'application',
+  Data: 'text',
 };

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -35,13 +35,7 @@ export const NETWORKS: Record<ChainId, Network> = {
 };
 
 // Other
-type mediaTypeIndex = 'All' | 'Image' | 'Movie' | 'Sound' | 'Other';
-
-type mediaTypeObject = {
-  [key in mediaTypeIndex]: string;
-};
-
-export const MEDIA_TYPE: mediaTypeObject = {
+export const MEDIA_TYPE = {
   All: 'all',
   Image: 'image',
   Movie: 'video',

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -35,11 +35,13 @@ export const NETWORKS: Record<ChainId, Network> = {
 };
 
 // Other
-type stringObject = {
-  [key: string]: string;
+type mediaTypeIndex = 'All' | 'Image' | 'Movie' | 'Sound' | 'Other';
+
+type mediaTypeObject = {
+  [key in mediaTypeIndex]: string;
 };
 
-export const MEDIA_TYPE: stringObject = {
+export const MEDIA_TYPE: mediaTypeObject = {
   All: 'all',
   Image: 'image',
   Movie: 'video',


### PR DESCRIPTION
## やったこと
- ソート機能の実装
- そのコンポーネントの共通化
UI参考：https://www.figma.com/file/JsiM09Uhbx9Z4dmVHgBBNU/%F0%9F%AA%A7-VWBL-Demo?node-id=1604%3A13739

## 問題点
- レスポンシブに幅を調整する際に、完全にNFTリストの幅に合わせることができなかった。

## その他
一覧ページでコンテンツのtitleやdescriptionと一緒にmimetypeも乗せた方が良いと思ったのですが、デザイン考える必要があったので一旦そっちは無視しました。分科会の議題に挙げても良いかも知れません(?)。