### PR TITLE
Opensea で売るにはリンクの追加、alt 属性の修正

### DIFF
--- a/src/components/common/custom-loading/custom-loading.tsx
+++ b/src/components/common/custom-loading/custom-loading.tsx
@@ -3,7 +3,7 @@ import { Container, Image, Text } from '@chakra-ui/react';
 export const CustomLoading = () => {
   return (
     <Container justifyContent='center' h='85vh' centerContent>
-      <Image src='/logo_blink.gif' alt='VWBL_logo' w={180} h={180} />
+      <Image src='/logo_blink.gif' alt='' w={180} h={180} />
       <Text fontWeight={'bold'} fontSize={'lg'}>
         Now Loading ...
       </Text>

--- a/src/components/common/file-previewer/file-previewer.tsx
+++ b/src/components/common/file-previewer/file-previewer.tsx
@@ -20,7 +20,7 @@ const switchPlayer = (url: string, mimeType?: string) => {
   } else if (mimeType?.includes('video')) {
     return <ReactPlayer url={url} controls={true} width='100%' height='100%' />;
   } else if (mimeType?.includes('pdf')) {
-    return <Image src='/pdf-icon.jpeg' alt='pdf-icon' maxH='100%' maxW='100%' />;
+    return <Image src='/pdf-icon.jpeg' alt='pdf' maxH='100%' maxW='100%' />;
   } else {
     return <Image src={url} alt='selectedFile' maxH='100%' maxW='100%' />;
   }

--- a/src/components/common/layout/layout.tsx
+++ b/src/components/common/layout/layout.tsx
@@ -81,12 +81,14 @@ export const Layout: React.FC = ({ children }) => {
     {
       title: 'Explore',
       to: 'https://vwbl-protocol.org/',
+      target: '_blank',
     },
     {
       title: 'Create',
       to: '/create',
     },
   ];
+  
 
   const FooterLinks: Link[] = [
     {
@@ -114,7 +116,7 @@ export const Layout: React.FC = ({ children }) => {
         <Flex h='76px' alignItems={'center'} justifyContent={'space-between'} mx='auto' maxW={{ md: '80%' }}>
           <Link href='/'>
             <a>
-              <Image src='/header-logo.svg' alt='header-logo' h={7} />
+              <Image src='/header-logo.svg' alt='VWBL Sample App' h={7} />
             </a>
           </Link>
           <HStack />

--- a/src/components/pages/home/components/hero/index.tsx
+++ b/src/components/pages/home/components/hero/index.tsx
@@ -31,7 +31,7 @@ export const HeroComponent: React.FC = memo(() => {
         <Text fontSize='2xl' fontWeight='bold' textAlign='center'>
           Only you can see it.
         </Text>
-        <Image src='/home_01.svg' alt='home_01' minW={{ md: 500 }} mx='auto' />
+        <Image src='/home_01.svg' alt='' minW={{ md: 500 }} mx='auto' />
       </Box>
     </Container>
   );

--- a/src/components/pages/home/components/howto/index.tsx
+++ b/src/components/pages/home/components/howto/index.tsx
@@ -2,6 +2,7 @@ import { Box, Container, Text, Tabs, TabList, Tab, TabPanels, TabPanel, Image, D
 import { Button } from '../../../../common/button';
 import { memo, useCallback, useState } from 'react';
 import { useRouter } from 'next/router';
+import { ExternalLinkIcon } from '@chakra-ui/icons';
 
 export const HowToComponent: React.FC = memo(() => {
   const tabOptions = [{ name: 'Create' }, { name: 'Transfer' }];
@@ -72,7 +73,7 @@ const HowToCreate: React.FC = memo(() => {
         <Text fontSize='md' my={10} textAlign='left' w={{ base: '100%', md: '60%' }}>
           メニューの「Connect Wallet」クリックし、Metamask Walletを接続する。
         </Text>
-        <Image src='/howto_01.gif' alt='howto_01' w={400} border='1px' />
+        <Image src='/howto_01.gif' alt='' w={400} border='1px' />
       </Box>
       <Divider my={10} />
       <Box>
@@ -83,7 +84,7 @@ const HowToCreate: React.FC = memo(() => {
           メニューの「Create」をクリックしVWBL NFT作成ページを開き、デジタルコンテンツの情報を入力する。 <br />
           全て入力したらページ下部「Create Item」ボタンでVWBL NFTを発行する。 アイテムの作成には数分かかる場合があります。
         </Text>
-        <Image src='/howto_02.gif' alt='howto_02' w={400} border='1px' />
+        <Image src='/howto_02.gif' alt='' w={400} border='1px' />
       </Box>
       <Divider my={10} />
       <Box>
@@ -94,10 +95,20 @@ const HowToCreate: React.FC = memo(() => {
           「My Wallet」をクリックし、保有しているVWBL NFTを表示する。VWBL NFTを選択した後、「View
           Data」をクリックしNFT保有者だけみることができる画像を閲覧する。
         </Text>
-        <Image src='/howto_03.gif' alt='howto_03' w={400} border='1px' />
+        <Image src='/howto_03.gif' alt='' w={400} border='1px' />
       </Box>
-
-      <Button text='Try demo' width={{ base: '100%', md: '60%' }} mt={10} onClick={() => router.push('/create')} />
+      <Box display='flex' alignItems='center' flexDir='column' gap={8}>
+        <Button text='Try demo' width={{ base: '100%', md: '60%' }} mt={10} onClick={() => router.push('/create')} />
+        <Link
+          color='blue.600'
+          href='https://ango-ya.notion.site/VWBL-NFT-OpenSea-fa6e5766bf3f4a809849e682d65fec8c'
+          isExternal
+          w={{ base: '100%', md: '60%' }}
+        >
+          VWBL NFTをOpenSeaで販売するには？
+          <ExternalLinkIcon mx='2px' />
+        </Link>
+      </Box>
     </Container>
   );
 });
@@ -130,7 +141,7 @@ const HowToTransfer: React.FC = memo(() => {
         <Text fontSize='md' my={10} w={{ base: '100%', md: '60%' }} textAlign='left'>
           メニューの「Connect Wallet」クリックし、メタマスクなどの仮想通貨ウォレットを接続する。
         </Text>
-        <Image src='/howto_01.gif' alt='howto_01' w={400} border='1px' />
+        <Image src='/howto_01.gif' alt='' w={400} border='1px' />
       </Box>
       <Divider my={10} />
       <Box w={'100%'}>
@@ -140,7 +151,7 @@ const HowToTransfer: React.FC = memo(() => {
         <Text fontSize='md' my={10} textAlign='left' w={{ base: '100%', md: '60%' }}>
           「My Wallet」をクリックし、保有しているVWBL NFTを表示する。
         </Text>
-        <Image src='/howto_03.gif' alt='howto_03' w={400} border='1px' />
+        <Image src='/howto_03.gif' alt='' w={400} border='1px' />
       </Box>
       <Divider my={10} />
       <Box w={'100%'}>
@@ -150,7 +161,7 @@ const HowToTransfer: React.FC = memo(() => {
         <Text fontSize='md' my={10} textAlign='left' w={{ base: '100%', md: '60%' }}>
           詳細ページに遷移した後、「Transfer」をクリックする。送信先のウォレットアドレスを入力し、送信する。
         </Text>
-        <Image src='/howto_04.gif' alt='howto_04' w={400} border='1px' />
+        <Image src='/howto_04.gif' alt='' w={400} border='1px' />
       </Box>
       <Button text='My Wallet' width={{ base: '100%', md: '60%' }} mt={10} onClick={() => router.push('/account')} />
     </Container>

--- a/src/components/pages/home/components/what-vwbl/index.tsx
+++ b/src/components/pages/home/components/what-vwbl/index.tsx
@@ -13,7 +13,7 @@ export const WhatVWBLComponent: React.FC = memo(() => {
           VWBL demoは{'"'}VWBL NFT{'"'}をミントできるアプリです！
           <br />
           誰でも無料で使えて、作ったNFTは
-          <Link color='blue.500' href='https://ango-ya.notion.site/VWBL-NFT-OpenSea-fa6e5766bf3f4a809849e682d65fec8c' isExternal>
+          <Link color='blue.600' href='https://ango-ya.notion.site/VWBL-NFT-OpenSea-fa6e5766bf3f4a809849e682d65fec8c' isExternal>
             openseaなどで売ることもできるよ！
             <ExternalLinkIcon mx='2px' />
           </Link>

--- a/src/components/pages/home/components/what-vwbl/index.tsx
+++ b/src/components/pages/home/components/what-vwbl/index.tsx
@@ -1,4 +1,5 @@
-import { Box, Text, Container, Image } from '@chakra-ui/react';
+import { ExternalLinkIcon } from '@chakra-ui/icons';
+import { Box, Text, Container, Image, Link } from '@chakra-ui/react';
 import { memo } from 'react';
 
 export const WhatVWBLComponent: React.FC = memo(() => {
@@ -11,11 +12,15 @@ export const WhatVWBLComponent: React.FC = memo(() => {
         <Text fontSize='md' mt={4} mb={10} fontWeight='bold' display='center' justifyContent='center'>
           VWBL demoは{'"'}VWBL NFT{'"'}をミントできるアプリです！
           <br />
-          誰でも無料で使えて、作ったNFTはopenseaなどで売ることもできるよ！
+          誰でも無料で使えて、作ったNFTは
+          <Link color='blue.500' href='https://ango-ya.notion.site/VWBL-NFT-OpenSea-fa6e5766bf3f4a809849e682d65fec8c' isExternal>
+            openseaなどで売ることもできるよ！
+            <ExternalLinkIcon mx='2px' />
+          </Link>
         </Text>
         <Box display={'flex'} justifyContent={'space-around'} mt={14}>
-          <Image src='/what-vwbl_01.png' alt='what-vwbl_01' w={{ base: 40, md: 400 }} />
-          <Image src='/what-vwbl_02.png' alt='home_01' w={{ base: 40, md: 400 }} />
+          <Image src='/what-vwbl_01.png' alt='' w={{ base: 40, md: 400 }} />
+          <Image src='/what-vwbl_02.png' alt='' w={{ base: 40, md: 400 }} />
         </Box>
       </Box>
     </Container>


### PR DESCRIPTION
### 「Opensea で売るには」のNotionリンクを追加（別タブで開く）
https://ango-ya.notion.site/VWBL-NFT-OpenSea-fa6e5766bf3f4a809849e682d65fec8c

- 1箇所目
VWBL demoは"VWBL NFT"をミントできるアプリです！
誰でも無料で使えて、作ったNFTはopenseaなどで売ることもできるよ！
`openseaなどで売ることもできるよ！`にリンク追加
<img width="1639" alt="Screenshot 2023-11-13 at 19 09 56" src="https://github.com/VWBL/VWBL-Sample-App/assets/83049657/2412673c-08c5-468f-9ead-1ccd70b4d003">

- 2箇所目
How to の1番下に追加
<img width="1111" alt="Screenshot 2023-11-13 at 19 10 04" src="https://github.com/VWBL/VWBL-Sample-App/assets/83049657/9296fb21-b6ae-4ff9-8bb9-6dc51a194151">

### alt 属性の修正
- 近くにあるテキストと内容が重複する画像：`alt=''`に変更
- 装飾目的の画像：`alt=''`に変更
- テキストとして使われている画像：表現されているテキストに変更


参考リンク
https://zenn.dev/pacchiy/articles/650e6212dee77b
https://www.w3.org/WAI/tutorials/images/decision-tree/