### PR TITLE
fix: change tab order

### DIFF
--- a/src/pages/receive/index.tsx
+++ b/src/pages/receive/index.tsx
@@ -29,10 +29,10 @@ export const ReceivePage: React.FC<Props> = ({}) => {
 
         <TabPanels mt={6}>
           <TabPanel>
-            <ReceivePdf />
+            <ReceiveAudio />
           </TabPanel>
           <TabPanel>
-            <ReceiveAudio />
+            <ReceivePdf />
           </TabPanel>
         </TabPanels>
       </Tabs>

--- a/src/pages/receive/index.tsx
+++ b/src/pages/receive/index.tsx
@@ -10,7 +10,7 @@ type Props = {
 };
 
 export const ReceivePage: React.FC<Props> = ({}) => {
-  const tabOptions = [{ name: 'PDF' }, { name: 'Music' }];
+  const tabOptions = [ { name: 'Music' },{ name: 'PDF' }];
   const [tabIndex, setTabIndex] = useState(0);
 
   const handleTabsChange = useCallback((index: number) => {


### PR DESCRIPTION
`/receive`
のページに遷移したときにMusicNFT が表示されるように修正しました
<img width="1626" alt="" src="https://github.com/user-attachments/assets/7c1e060b-e9f1-491b-ac78-64f91256f2bf">






