### PR TITLE
Update deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,8 +42,10 @@ jobs:
           path: '**/node_modules'
 
       - name: Install Dependencies
-        if: steps.cache_node_modules.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile
+        # if: steps.cache_node_modules.outputs.cache-hit != 'true'
+        run: |
+          rm -rf **/node_modules
+          yarn install --frozen-lockfile
 
   deploy-staging:
     if: github.ref == 'refs/heads/develop'


### PR DESCRIPTION

https://github.com/VWBL/VWBL-Sample-App/actions
の対応

```
Post job cleanup.
Error: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

yarn installが失敗している可能性があるので、一時的に強制的に再インストール、エラー解消確認後に元に戻します。